### PR TITLE
Add service collaboration patterns spec and prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ This project helps developers and AI systems identify and understand:
    - `design-patterns-spec.yaml`: Design pattern specification template
    - `algorithms-data-structures-spec.yaml`: Algorithm/DS specification template
    - `cloud-architecture-spec.yaml`: Cloud architecture pattern template
+   - `service-collaboration-patterns.yaml`: Collaboration pattern reference
 
 4. **Generate Documentation**: Extend `scripts/generate_from_spec.py` to process specifications and generate pattern documentation.
+   - `scripts/generate_service_collab_prompt.py` outputs a prompt listing supported collaboration patterns.
 
 5. **CLI Tool Usage**: Use the command-line tool to analyze any codebase:
    ```bash

--- a/prompts/service-collaboration-prompt.md
+++ b/prompts/service-collaboration-prompt.md
@@ -1,0 +1,31 @@
+# Service Collaboration Scan Prompt
+
+Use this prompt to identify service collaboration patterns in a codebase.
+
+## Role Definition
+You are an AI code auditor. Utilize collaboration pattern specs from the `specs/` directory (e.g., `saga-pattern.yaml`, `api-composition.yaml`) to identify and analyze service collaboration patterns in [CODE_PATH].
+
+## Key Responsibilities
+- Detect service collaboration patterns using hints.
+- Match findings to known patterns from the specs.
+- Generate reports including coordination strategy and potential scaling opportunities.
+
+## Approach
+1. Load all spec files under `specs/` that define `service_collaboration_patterns`.
+2. Traverse the source files in [CODE_PATH].
+3. Match code features against hints to identify candidate patterns.
+4. Populate `report_fields` with findings.
+5. Reference `scaling_opportunities` where relevant.
+
+## Specific Tasks
+- Report the file and function where each collaboration pattern is detected.
+- Name the matched pattern (e.g., Saga, API Composition).
+- List matched hints.
+- Fill in `report_fields` such as coordination style, retry policy, etc.
+- Suggest refactors if `scaling_opportunities` apply.
+
+## Additional Considerations
+- Highlight anti-patterns or tight coupling.
+- Prefer asynchronous, decoupled architectures where beneficial.
+- Ensure each finding maps clearly to a spec-defined pattern.
+- Output results in YAML for each pattern detected.

--- a/scripts/generate_service_collab_prompt.py
+++ b/scripts/generate_service_collab_prompt.py
@@ -1,0 +1,29 @@
+"""Generate a service collaboration scan prompt.
+
+This script loads the aggregated service collaboration spec and prints
+out a basic prompt with placeholders for a target code path.
+"""
+
+import yaml
+from pathlib import Path
+
+SPEC_PATH = Path(__file__).resolve().parent.parent / "specs" / "service-collaboration-patterns.yaml"
+
+
+def load_spec(path: Path):
+    with path.open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def build_prompt(spec):
+    patterns = [p["name"] for p in spec.get("service_collaboration_patterns", [])]
+    pattern_list = ", ".join(patterns)
+    return f"""# Service Collaboration Scan Prompt\n\n" \
+           f"Supported patterns: {pattern_list}.\n" \
+           "Provide CODE_PATH when invoking this script to fill in the target repository."""
+
+
+if __name__ == "__main__":
+    spec = load_spec(SPEC_PATH)
+    prompt = build_prompt(spec)
+    print(prompt)

--- a/specs/service-collaboration-patterns.yaml
+++ b/specs/service-collaboration-patterns.yaml
@@ -1,0 +1,122 @@
+service_collaboration_patterns:
+  - name: "Orchestration"
+    category: "coordination"
+    implementation_complexity: Medium
+    detection_complexity: Moderate
+    hints:
+      - "workflow engine"
+      - "central coordinator"
+      - "calls multiple services"
+    report_fields:
+      - coordination_style
+      - participating_services
+    scaling_opportunities:
+      - symptom: "central point of failure"
+        suggestion: "decentralize using choreography"
+
+  - name: "Choreography"
+    category: "coordination"
+    implementation_complexity: Medium
+    detection_complexity: Moderate
+    hints:
+      - "event emitter"
+      - "subscribes to events"
+    report_fields:
+      - event_topics
+      - downstream_reactions
+    scaling_opportunities:
+      - symptom: "unobservable service mesh"
+        suggestion: "add event tracing with correlation IDs"
+
+  - name: "Saga"
+    category: "messaging_consistency"
+    implementation_complexity: High
+    detection_complexity: Moderate
+    hints:
+      - "compensation"
+      - "orchestrator"
+      - "Temporal"
+    report_fields:
+      - coordination_style
+      - compensation_strategy
+      - retry_policy
+    scaling_opportunities:
+      - symptom: "saga orchestrator tightly coupled"
+        suggestion: "move to event-driven saga choreography"
+
+  - name: "API Composition"
+    category: "microservices"
+    implementation_complexity: Medium
+    detection_complexity: Low
+    hints:
+      - "aggregates multiple APIs"
+      - "gateway service"
+    report_fields:
+      - composition_strategy
+      - service_dependencies
+    scaling_opportunities:
+      - symptom: "slow joins from downstream APIs"
+        suggestion: "add cache or async batch fetching"
+
+  - name: "Synchronous Request-Response"
+    category: "communication"
+    implementation_complexity: Low
+    detection_complexity: Low
+    hints:
+      - "HTTP request to another service"
+      - "grpc call"
+    report_fields:
+      - downstream_services
+      - timeout_strategy
+    scaling_opportunities:
+      - symptom: "latency or timeout failures"
+        suggestion: "move to async messaging"
+
+  - name: "Asynchronous Messaging"
+    category: "communication"
+    implementation_complexity: Medium
+    detection_complexity: Low
+    hints:
+      - "Kafka"
+      - "message broker"
+      - "queue consumption"
+    report_fields:
+      - message_broker
+      - topic_names
+    scaling_opportunities:
+      - symptom: "unbounded queues"
+        suggestion: "add dead-letter queues and backpressure"
+
+  - name: "Command Messaging"
+    category: "communication"
+    implementation_complexity: Medium
+    detection_complexity: Low
+    hints:
+      - "send command"
+      - "command bus"
+    report_fields:
+      - command_names
+      - handler_services
+
+  - name: "Event-Carried State Transfer"
+    category: "data_consistency"
+    implementation_complexity: High
+    detection_complexity: Moderate
+    hints:
+      - "event includes full entity state"
+      - "event replay for rehydration"
+    report_fields:
+      - event_payload_structure
+      - downstream_state_mirrors
+
+  - name: "CQRS"
+    category: "data_modeling"
+    implementation_complexity: Medium
+    detection_complexity: Moderate
+    hints:
+      - "query handler"
+      - "command handler"
+      - "separate read/write services"
+    report_fields:
+      - read_model_strategy
+      - write_model_strategy

--- a/tests/test_service_collab_prompt.py
+++ b/tests/test_service_collab_prompt.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+try:
+    from scripts.generate_service_collab_prompt import load_spec, build_prompt, SPEC_PATH
+except ModuleNotFoundError:
+    import pytest
+    pytest.skip("PyYAML not installed", allow_module_level=True)
+
+
+def test_load_spec():
+    spec = load_spec(SPEC_PATH)
+    assert "service_collaboration_patterns" in spec
+
+
+def test_build_prompt():
+    spec = {"service_collaboration_patterns": [{"name": "Saga"}, {"name": "API Composition"}]}
+    prompt = build_prompt(spec)
+    assert "Saga" in prompt
+    assert "API Composition" in prompt


### PR DESCRIPTION
## Summary
- document service collaboration patterns under `specs/`
- add prompt for scanning service collaboration patterns
- provide script to generate a prompt listing supported patterns
- mention new spec and script in README
- basic tests for the new script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aa789c654832dab475ee5d91a4fc2